### PR TITLE
Skip Adding "Generic EC" FAN Tachometer

### DIFF
--- a/HWMonitorSMC/HWMonitorSensors/HWSensorScanner.swift
+++ b/HWMonitorSMC/HWMonitorSensors/HWSensorScanner.swift
@@ -705,7 +705,11 @@ class HWSensorsScanner: NSObject {
         if multi == 0 { multi = 1 }
         
         let actionType : ActionType = .systemLog
-        if key.range(of: "FAN") != nil {
+        
+        // Skip Adding "Generic EC" FAN Sensor
+        let skipggenericec = getSuperIOChipName()
+        
+        if key.range(of: "FAN") != nil && skipggenericec != "Generic EC" {
           guard let val = sensors.object(forKey: k) as? Double else {
             continue
           }


### PR DESCRIPTION
When using "Generic EC" Controller in SMCSuperIO, the detected FAN doesn't show more than 1 fan device and doesn't update. 
By adding the extra condition the SMCSuperIO Fan sensors get recognized and update correctly.